### PR TITLE
Fix gQueryCodegen config typos

### DIFF
--- a/docs/src/docs.md
+++ b/docs/src/docs.md
@@ -35,7 +35,7 @@ vite: {
 			// Required
 			// schema: 'http://localhost:3001/graphql' // this can also be a url to a graphql api
 			schema: './src/lib/graphql/schema.graphql', // path to schema, schema is required
-			output: './src/lib/graphql', // Where you want the general schema types to output
+			out: './src/lib/graphql', // Where you want the general schema types to output
 			gPath: '$lib/config/g', // Path to g, created in step 1.
 			// Optional
 			debug: false  // boolean, this adds logging for gq files deleted and on codegen

--- a/docs/src/docs.md
+++ b/docs/src/docs.md
@@ -36,7 +36,7 @@ vite: {
 			// schema: 'http://localhost:3001/graphql' // this can also be a url to a graphql api
 			schema: './src/lib/graphql/schema.graphql', // path to schema, schema is required
 			output: './src/lib/graphql', // Where you want the general schema types to output
-			gPath: '$lib/config/g' // Path to g, created in step 1.
+			gPath: '$lib/config/g', // Path to g, created in step 1.
 			// Optional
 			debug: false  // boolean, this adds logging for gq files deleted and on codegen
 		})


### PR DESCRIPTION
Thanks for publishing this awesome library! 

I got a little tripped up with the docs, and after watching [your video on YouTube](https://www.youtube.com/watch?v=sjPJLwIA7SY&t=1017s) I noticed a little error in the config instructions for `gQueryCodegen`