### PR TITLE
Config.kit.target is no longer required, and should be removed

### DIFF
--- a/example/svelte.config.js
+++ b/example/svelte.config.js
@@ -8,7 +8,6 @@ const config = {
 
 	kit: {
 		adapter: adapter(),
-		target: '#svelte',
 		vite: {
 			plugins: [
 				gQueryCodegen({


### PR DESCRIPTION
When trying to run the example, I ran into this.  It was a quick fix