### PR TITLE
Allow custom fetch on mutations (small PR)

### DIFF
--- a/codegen/codegen.js
+++ b/codegen/codegen.js
@@ -27,6 +27,7 @@ export const plugin = (schema, documents, config) => {
     const defaultTypes = `
 type SubscribeWrapperArgs<T> = {
 	variables?: T,
+    fetch?: typeof fetch;
 }
 
 interface CacheFunctionOptions {
@@ -66,7 +67,7 @@ export async function get${pascalName}({ fetch, variables }: GGetParameters<${op
                 // This is where the mutation code is generated
                 // We're grabbing the mutation name and using it as a string in the generated code
                 operations += `
-export const ${name} = ({ variables }: SubscribeWrapperArgs<${opv}>):
+export const ${name} = ({ variables, fetch = window?.fetch }: SubscribeWrapperArgs<${opv}>):
 Promise<GFetchReturnWithErrors<${op}>> =>
 	g.fetch<${op}>({
 		queries: [{ query: ${pascalName}Doc, variables }],

--- a/codegen/codegen.ts
+++ b/codegen/codegen.ts
@@ -63,6 +63,7 @@ export const plugin: PluginFunction<any> = (
   const defaultTypes = `
 type SubscribeWrapperArgs<T> = {
 	variables?: T,
+  fetch?: typeof fetch
 }
 
 interface CacheFunctionOptions {
@@ -102,7 +103,7 @@ export async function get${pascalName}({ fetch, variables }: GGetParameters<${op
           // This is where the mutation code is generated
           // We're grabbing the mutation name and using it as a string in the generated code
           operations += `
-export const ${name} = ({ variables }: SubscribeWrapperArgs<${opv}>):
+export const ${name} = ({ variables, fetch = window?.fetch }: SubscribeWrapperArgs<${opv}>):
 Promise<GFetchReturnWithErrors<${op}>> =>
 	g.fetch<${op}>({
 		queries: [{ query: ${pascalName}Doc, variables }],

--- a/docs/src/docs.md
+++ b/docs/src/docs.md
@@ -296,7 +296,8 @@ export async function getAdminTags(
 }
 
 export const deleteTag = ({
-	variables
+	variables,
+	fetch = window?.fetch
 }: SubscribeWrapperArgs<DeleteTagMutationVariables>): Promise<
 	GFetchReturnWithErrors<DeleteTagMutation>
 > =>

--- a/example/src/lib/listing/Series.gq.ts
+++ b/example/src/lib/listing/Series.gq.ts
@@ -18,6 +18,7 @@ type FetchWrapperArgs<T> = {
 
 type SubscribeWrapperArgs<T> = {
 	variables?: T,
+	fetch?: typeof fetch,
 }
 
 interface CacheFunctionOptions {


### PR DESCRIPTION
Currently, queries accept a custom fetch (mainly for SvelteKit's SSR fetch) but mutations use the browser's fetch, since they will always have access to it. This PR will allow the developer to pass a custom `fetch` to both.

## Why?
For those of us using external apis and needing to add an Authorization header to the request. Like the SvelteKit [RealWorld example app](https://github.com/sveltejs/realworld), I store a jwt in a cookie, receive the cookie in the `handle` hook, and put the jwt in the `session`. In order to hit the external api directly with gQuery rather than routing everything through a SvelteKit endpoint, it makes sense to retrieve the token from the session store whenever I need to hit the api. Given access to the fetch function, I can easily wrap `fetch` and add the token to the Authorization header. But gQuery's current implementation doesn't allow for this on mutations since I have no access to the `fetch` function being used.